### PR TITLE
COMP: Bump itk-ants to 0.6.0

### DIFF
--- a/ANTsRegistration/ANTsRegistration.py
+++ b/ANTsRegistration/ANTsRegistration.py
@@ -897,10 +897,8 @@ class ANTsRegistrationLogic(ITKANTsCommonLogic):
         fixedImage = slicer.util.itkImageFromVolume(stages[0]["metrics"][0]["fixed"])
         movingImage = slicer.util.itkImageFromVolume(stages[0]["metrics"][0]["moving"])
 
-        # initial_itk_transform = itk.IdentityTransform[precision_type, fixedImage.ndim].New()  # not wrapped for float in 5.3
-        initial_itk_transform = itk.AffineTransform[
-            precision_type, fixedImage.ndim
-        ].New()
+        initial_itk_transform = itk.AffineTransform[precision_type, fixedImage.ndim].New()  # not wrapped for float in 5.3
+        initial_itk_transform.SetIdentity()
         if "initialTransformNode" in initialTransformSettings:
             print("Passing Slicer nodes to ITK filters is not yet implemented")
             # initial_itk_transform = slicer.util.itkTransformFromTransformNode(
@@ -914,8 +912,7 @@ class ANTsRegistrationLogic(ITKANTsCommonLogic):
         startTime = time.time()
         antsCommand = ""
         for stage_index, stage in enumerate(stages):
-            # TODO: update name (ANTS->ANTs), use precision_type in instantiation
-            ants_reg = itk.ANTSRegistration[type(fixedImage), type(movingImage)].New()
+            ants_reg = itk.ANTSRegistration[type(fixedImage), type(movingImage), precision_type].New()
             ants_reg.SetFixedImage(fixedImage)
             ants_reg.SetMovingImage(movingImage)
             ants_reg.SetInitialTransform(initial_itk_transform)

--- a/ITKANTsCommon/ITKANTsCommon.py
+++ b/ITKANTsCommon/ITKANTsCommon.py
@@ -76,7 +76,7 @@ class ITKANTsCommonLogic(ScriptedLoadableModuleLogic):
             if not install:
                 logging.info("Installation of ITK aborted by the user")
                 return None
-        slicer.util.pip_install("itk-ants>=0.2.0")
+        slicer.util.pip_install("itk-ants>=0.6.0")
         import itk
 
         logging.info(f"ITK {itk.__version__} installed correctly")


### PR DESCRIPTION
Uses ITK 5.4.0 -> requires 5.7.0-2024-06-04 or later.

Also enable IdentityTransform initialization and selection of precision.
